### PR TITLE
1.0.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,11 +37,12 @@ function puggc(answer) {
   const output = String(nggc.stdout).split("\n")[0].split(" ")[1];
   const path = output.substring(0, output.lastIndexOf("/"));
   const name = path.split("/").at(-1);
-  const style = fs.readdirSync(path).reduce((file) => {
-    if (file.includes("css")) {
-      return file.substring(file.lastIndexOf("."));
-    }
-  });
+
+  const style = fs
+    .readdirSync(path)
+    .map((file) => file.substring(file.lastIndexOf(".")))
+    .find((ext) => ext.includes("css"));
+
   const file = (extension) => {
     return path + "/" + name + ".component" + extension;
   };

--- a/index.js
+++ b/index.js
@@ -33,7 +33,38 @@ function puggc(answer) {
     return;
   }
 
-  // get path to component from the ng g c output
+  // get component files from the ng g c output
+  // nggc.stdout -> { fileType: fileName }
+  const files = String(nggc.stdout)
+    .split("\n")
+    .reduce((obj, line) => {
+      if (!line.includes("CREATE")) {
+        return obj;
+      }
+
+      line = line.split(" ")[1];
+      const extIndex = line.lastIndexOf(".");
+      const ext = line.substring(extIndex);
+
+      if (ext.includes("css")) {
+        obj.style = line;
+        obj.stylePref = line.substring(0, extIndex) + answer.style;
+      }
+      if (ext === ".html") {
+        obj.html = line;
+        obj.pug = line.substring(0, extIndex) + ".pug";
+      }
+      if (ext === ".ts") {
+        if (line.substring(line.lastIndexOf(".", extIndex - 1)) === ".spec") {
+          obj.spec = line;
+        } else {
+          obj.ts = line;
+        }
+      }
+
+      return obj;
+    }, {});
+
   const output = String(nggc.stdout).split("\n")[0].split(" ")[1];
   const path = output.substring(0, output.lastIndexOf("/"));
   const name = path.split("/").at(-1);

--- a/index.js
+++ b/index.js
@@ -5,6 +5,13 @@ const iq = require("inquirer");
 
 const args = process.argv.slice(2);
 if (args.length) {
+  const nggc = cp.spawnSync("ng", ["g", "c", args[0]]);
+
+  if (String(nggc.stderr)) {
+    console.log(String(nggc.stderr));
+    return;
+  }
+
   iq.prompt([
     {
       name: "style",
@@ -18,21 +25,12 @@ if (args.length) {
       type: "list",
       choices: ["include", "remove"],
     },
-  ]).then((answer) => puggc(answer));
+  ]).then((answer) => puggc(answer, nggc));
 } else {
   console.error("puggc ERROR: must pass a component name");
 }
 
-function puggc(answer) {
-  const nggc = cp.spawnSync("ng", ["g", "c", args[0]]);
-
-  if (String(nggc.stderr)) {
-    console.error(
-      "puggc ERROR: error executing ng g c - " + String(nggc.stderr)
-    );
-    return;
-  }
-
+function puggc(answer, nggc) {
   // get component files from the ng g c output
   // nggc.stdout -> { fileType: fileName }
   const files = String(nggc.stdout)

--- a/index.js
+++ b/index.js
@@ -105,5 +105,12 @@ function puggc(answer) {
 
   fs.writeFileSync(files.ts, contents);
 
-  console.log("\x1b[32m✓ \x1b[0mCREATED component:", path);
+  const terminalColor = (color, text) => {
+    return color + text;
+  };
+  const green = (text) => terminalColor("\x1b[32m", text);
+  const reset = (text) => terminalColor("\x1b[0m", text);
+  const cyan = (text) => terminalColor("\x1b[36m", text);
+
+  console.log(green("✓"), reset("CREATED component:"), cyan(files.ts));
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "puggc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Generate Angular components with .pug instead of .html",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Bug fix and prep for 1.0.3 which will focus on ng g c -- flags. 
- Get individual files and paths from ng g c output which presumably will work better with the -- flags and their changes to component structure.
  - Additionally fixes error and edge case caused by the `.includes("css")` line.
- Execute `ng g c` before user input to show any errors immediately.